### PR TITLE
Add node as prerequisite and fix clean up command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Prerequisites:
 - AWS SAM CLI
 - AWS User connected to CLI
 - Discord Application created and invited to your test guild
+- Node.js
 
 ### Clone the boilerplate and install required packages
 Clone this repo with AWS SAM
@@ -67,7 +68,7 @@ sam build && sam deploy
 
 ## Clean all
 ```
-sam destroy
+sam delete
 ```
 
 


### PR DESCRIPTION
Node.js is required for `npm install`.
The command for pulling down the stack is `sam delete` not `sam destroy`. See [resource](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-delete.html)